### PR TITLE
Fix cfg input invalid

### DIFF
--- a/src/main/java/objectCreatorHelper/PayloadFieldCreator.java
+++ b/src/main/java/objectCreatorHelper/PayloadFieldCreator.java
@@ -157,6 +157,20 @@ public class PayloadFieldCreator {
 				payloadField.setUint8(i);
 
 			}
+			if (dataType == DataTypeList.string) {
+				dcpTestProcedure.ReceivingPayloadField.String i = new dcpTestProcedure.ReceivingPayloadField.String();
+				//i.setMin( dcpWrapper.getMinForVr(valueReference));
+				//i.setMax( dcpWrapper.getMaxForVr(valueReference));
+				payloadField.setString(i);
+
+			}
+			if (dataType == DataTypeList.binary) {
+				dcpTestProcedure.ReceivingPayloadField.Binary i = new dcpTestProcedure.ReceivingPayloadField.Binary();
+				//i.setMin((short) dcpWrapper.getMinForVr(valueReference));
+				//i.setMax((short) dcpWrapper.getMaxForVr(valueReference));
+				payloadField.setBinary(i);
+
+			}
 
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/main/java/objectCreatorHelper/TransitionCreator.java
+++ b/src/main/java/objectCreatorHelper/TransitionCreator.java
@@ -624,7 +624,7 @@ public class TransitionCreator {
 		if (configInfo.getSourceDataType().getInvalid() != null) {
 
 			try {
-				configInput.setSourceDataType(dcpWrapper.getInvalidDataTypeFromVr(randValueReference));
+				configInput.setSourceDataType(dcpWrapper.getInvalidDataTypeFromVr(configInput.getTargetVr().intValue()));
 			} catch (Exception e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
When using CFG_input to check for rejection on pdus with invalid datatype(as in the predefined template)
the selection of which datatype is used as invalid  was based on random input(=1st in description). Now based on current variable.
Reproduce: Slave with two inputs of different data types(*).
Unrelated: string and binary DAT PDUs should be accepted.